### PR TITLE
Some opti

### DIFF
--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -24,7 +24,7 @@ Console.WriteLine(Y[0].Data);
 
 
 int epochs = 1000;
-double lr = 0.0000000001;
+double lr = 1e-9;
 
 double lastLoss = double.MaxValue;
 

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -64,7 +64,6 @@ for (int i = 0; i < epochs; i++)
 
     loss.Backpropagate();
     cerebrin.Step(lr);
-    loss.ResetGrad();
 
     Console.WriteLine("Loss: " + loss.Data);
     DataSet.Scatter(preds);

--- a/SharpGrad/Value.cs
+++ b/SharpGrad/Value.cs
@@ -83,27 +83,21 @@ namespace SharpGrad.DifEngine
                 LeftChildren.Grad += Grad;
         }
 
-        #region BACKPROPAGATION
-        void DFS(List<Value> TopOSort, HashSet<Value> Visited)
+        protected void Backpropagate_()
         {
-            Visited.Add(this);
-            if (LeftChildren != null && !Visited.Contains(LeftChildren))
-                LeftChildren.DFS(TopOSort, Visited);
-            if (RightChildren != null && !Visited.Contains(RightChildren))
-                RightChildren.DFS(TopOSort, Visited);
-            TopOSort.Add(this);
+            if (Grad > 0)
+            {
+                Backward();
+                LeftChildren?.Backpropagate_();
+                RightChildren?.Backpropagate_();
+            }
         }
 
+        #region BACKPROPAGATION
         public void Backpropagate()
         {
             Grad = 1.0;
-            List<Value> TopOSort = new List<Value>();
-            HashSet<Value> Visited = new HashSet<Value>();
-            DFS(TopOSort, Visited);
-            for(int i = TopOSort.Count - 1; i >= 0; i--)
-            {
-                TopOSort[i].Backward();
-            }
+            Backpropagate_();
         }
         #endregion
 

--- a/SharpGrad/Value.cs
+++ b/SharpGrad/Value.cs
@@ -105,12 +105,6 @@ namespace SharpGrad.DifEngine
                 TopOSort[i].Backward();
             }
         }
-
-        public void ResetGrad()
-        {
-            LeftChildren?.ResetGrad();
-            RightChildren?.ResetGrad();
-        }
         #endregion
 
         public static implicit operator Value(double d)


### PR DESCRIPTION
I've miss function and call flow that was fully use less after the rewrite (ResetGrad() by exemple)
I've removed the creation of the graph using Visited and TopOSort. The backpropagation itselft flow directly from the loss.Backpropagate() node and internaly call LeftChildren.Backpropagate_() and RightChildren.Backpropagate_() recursively.

I've miss to update the readme in accordance :/